### PR TITLE
Remove duplicate export

### DIFF
--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -5,6 +5,4 @@ const rootReducer = combineReducers({
   map: mapReducer,
 });
 
-export type RootState = ReturnType<typeof rootReducer>;
-
 export default rootReducer;


### PR DESCRIPTION
delete unused export type in rootReducer (already exporting it in store.ts)